### PR TITLE
Add GitLab CI support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+image: erlang
+
+build:
+  stage: build
+  script:
+    - make
+  artifacts:
+    paths:
+      - ebin
+      - deps
+      - doc
+      - priv
+
+test:
+  stage: test
+  script:
+    - make eunit


### PR DESCRIPTION
This is for use in the GitLab mirror at https://gitlab.com/triqng/triq.