### PR TITLE
Fix error while building edocs

### DIFF
--- a/src/triq_dom.erl
+++ b/src/triq_dom.erl
@@ -635,7 +635,7 @@ pos_integer() ->
 %%
 %% Note, this is sized to ensure it remains a big integer, even on 64
 %% bit implementations.
-%% @spec largeint() -> domrec(largeint()).
+%% @spec largeint() -> domrec(largeint())
 largeint() ->
     #?DOM{
         kind=largeint,

--- a/src/triq_dom.erl
+++ b/src/triq_dom.erl
@@ -794,7 +794,7 @@ bitstring_shrink(#?DOM{kind=#bitstring{size=Size}, empty_ok=EmptyOK}=BinDom,
     end.
 
 %% @doc The domain of atoms
-%% @spec int() -> domain(integer())
+%% @spec atom() -> domain(integer())
 -spec atom() -> domrec(atom()).
 atom() ->
     #?DOM{kind=#atom{size=any},


### PR DESCRIPTION
INFO:  Regenerating edocs for triq
./src/triq_dom.erl, function largeint/0: at line 638: unknown error parsing specification: {638,edoc_parser,
                                      ["syntax error before: ","'.'"]}.
edoc: skipping source file './src/triq_dom.erl': {'EXIT',error}.
...
./src/triq_dom.erl, function atom/0: at line 797: spec name does not match.
edoc: skipping source file './src/triq_dom.erl': {'EXIT',error}

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>