### PR TITLE
Disable warnings_as_errors

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{erl_opts, [warnings_as_errors]}.
+{erl_opts, []}.
 {cover_enabled, true}.
 {erl_first_files, ["src/triq_autoexport.erl"]}.
 {qc_opts, [{qc_mod, triq}]}.


### PR DESCRIPTION
With the deprecation of gen_fsm and Triq's continued support of it,
there are warnings we cannot fix right now. Also, Werror is generally a
risky option, since there can always be unexpected warnings which then
cause the build to fail.