### PR TITLE
Improve Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: erlang
 otp_release:
+  - 20.1.5
   - 20.0.4
   - 19.0
   - 18.3
@@ -12,7 +13,7 @@ otp_release:
 env: MAKE_TARGET=ci
 matrix:
   include:
-    - otp_release: 20.0.4
+    - otp_release: 20.1.5
       env: MAKE_TARGET=ci-dialyze
 script: make $MAKE_TARGET
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,23 @@
+sudo: false
 language: erlang
 otp_release:
-   - 19.0
-   - 18.3
-   - 17.3
-   - 17.1
-   - 17.0
-   - R16B03
-   - R15B03
-   - R16B03-1
-   - R16B02
-   - R16B01
+  - 20.0.4
+  - 19.0
+  - 18.3
+  - 17.3
+  - 17.1
+  - 17.0
+  - R16B03-1
+  - R15B03
+env: MAKE_TARGET=ci
+matrix:
+  include:
+    - otp_release: 20.0.4
+      env: MAKE_TARGET=ci-dialyze
+script: make $MAKE_TARGET
+cache:
+  directories:
+    - .rebar
+before_cache:
+  - rm -fv .rebar/erlcinfo
+  - rm -fv $HOME/.cache/.rebar/erlcinfo

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@
 all:
 	./rebar compile
 
-test: eunit qc
+test: xref eunit qc
+
+ci: clean debug test
+
+ci-dialyze: clean debug dialyze
 
 doc:
 	./rebar doc
@@ -27,11 +31,17 @@ doc:
 clean:
 	./rebar clean
 
-dialyzer:
-	./rebar analyze
+xref:
+	./rebar xref
 
 eunit:
 	./rebar eunit
 
 qc:
 	./rebar qc
+
+maybe_build_plt:
+	./rebar -vv check-plt || ./rebar -vv build-plt
+
+dialyze: maybe_build_plt
+	./rebar -vv dialyze


### PR DESCRIPTION
- Run Dialyzer in a separate job, for the latest OTP release only.
- Run xref.
- Implement a custom script instead of Travis-CI default rebar task.