### PR TITLE
gitlab-ci: fix Dialyzer stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,9 +74,11 @@ test:20:
   <<: *test_job_definition
   image: erlang:20
 
-dialyze:20:
-  stage: dialyze
+test:dialyze:
+  stage: test
   image: erlang:20
+  dependencies:
+    - default-build
   script:
     - ./rebar check-plt || ./rebar -vv build-plt
     - ./rebar -vv dialyze


### PR DESCRIPTION
There are only 3 supported stages (build, test, deploy) which are not
going to be removed in the 10.0 release and we cannot define custom
stages.