### PR TITLE
gitlab-ci: no need to run xref

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ cache:
   stage: build
   script:
     - make
-    - ./rebar xref
     - rm .rebar/erlcinfo
 
 .artifact_paths_template: &artifact_paths_defitinion


### PR DESCRIPTION
We run Dialyzer anyway, so remove the xref call that was added in the
previous diff to .gitlab-ci.yml. It provokes unnecessary warnings.