### PR TITLE
Autoexport EUnit property wrappers

### DIFF
--- a/src/triq_autoexport.erl
+++ b/src/triq_autoexport.erl
@@ -35,11 +35,11 @@ parse_transform(Forms, Options) ->
     F = fun (Form, Set) ->
                 t_form(Form, Set, PropPrefix)
         end,
-    Exports = sets:to_list(lists:foldl(F, sets:new(), Forms)),
+    PropExports = sets:to_list(lists:foldl(F, sets:new(), Forms)),
     EUnit = maybe_gen_eunit(PropPrefix, Forms),
-    Forms1 = t_rewrite(Forms, Exports),
+    EUnitExports = lists:map(fun ({function, _, Name, 0, _}) -> {Name, 0} end, EUnit),
+    Forms1 = t_rewrite(Forms, PropExports ++ EUnitExports),
     add_eunit(Forms1, EUnit).
-
 
 t_form({function, _L, Name, 0, _Cs}, S, PropPrefix) ->
     N = atom_to_list(Name),


### PR DESCRIPTION
This makes `-triq(eunit)` module attribute actually work.

Tested manually by creating `test/triq_autoexport_test.erl` file with the following contents:

```erlang
-module(triq_autoexport_test).

-triq(eunit).

-include_lib("triq/include/triq.hrl").

prop_fail() ->
    ?FORALL(_, any(), false).
```

With that file, `./rebar eunit` is expected to fail.

Ideally, we should have an automated way to test this parse transform.