### PR TITLE
Dialyzer: fix contract and potential infinite loop

### DIFF
--- a/src/triq_dom.erl
+++ b/src/triq_dom.erl
@@ -1471,11 +1471,9 @@ unicode_binary(Encoding) ->
 
 %% @doc Generate an unicode binary.
 -spec unicode_binary(Size, Encoding) -> domrec(binary()) when
-      Size :: non_neg_integer() | undefined,
+      Size :: non_neg_integer() | 'any',
       Encoding :: unicode:encoding().
 
-unicode_binary(undefined, Encoding) ->
-    unicode_binary(any, Encoding);
 unicode_binary(Size, Encoding) ->
     #?DOM{kind=#unicode_binary{size=Size, encoding=Encoding},
           pick=fun unicode_binary_pick/2,


### PR DESCRIPTION
'any' is used for size=any, even though it's easy to confuse with any().
It's not a type but a plain atom.

This was introduced in ebd20fc4d6d810ba5574dbc15a06c707f213b543