### PR TITLE
Improve choose/2 and int/2 generators

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -17,3 +17,4 @@ Loic Hoguin
 Zachary Kessin
 Krzysztof Jurewicz
 Harlan Lieberman-Berg
+Nick Vatamaniuc

--- a/test/triq_tests.erl
+++ b/test/triq_tests.erl
@@ -219,7 +219,14 @@ vector_test() ->
 choose_test_() ->
     [?_assertEqual([3], triq:counterexample(?FORALL(_, choose(3,7), false))),
      ?_assertEqual([7], triq:counterexample(?FORALL(I, choose(3,7), I < 7))),
-     ?_assertEqual([3], triq:counterexample(?FORALL(_, choose(3,3), false)))].
+     ?_assertEqual([3], triq:counterexample(?FORALL(_, choose(3,3), false))),
+     ?_assertEqual([0], triq:counterexample(?FORALL(_, choose(-3,7), false))),
+     ?_assertEqual([-3], triq:counterexample(?FORALL(_, choose(-7,-3), false))),
+     ?_assertEqual([0], triq:counterexample(?FORALL(_, choose(-3,0), false))),
+     ?_assertEqual([0], triq:counterexample(?FORALL(_, choose(0,3), false))),
+     ?_assertEqual([1], triq:counterexample(?FORALL(_, choose(1,100), false))),
+     ?_assertEqual([5], triq:counterexample(?FORALL(_, choose(5,1 bsl 80), false))),
+     ?_assertException(error, function_clause, choose(7,3))].
 
 %%
 %% Test binary shrinking


### PR DESCRIPTION
~Fix int(Min, Max) to respect Min and Max limits when shrinking~

~The new behavior is try to shrink towards 0, but without going over the Min or~
~Max limits.~

(See discussion below. PR was updated with new behavior) 

Fixes #66