### PR TITLE
pages: link to index from contributing

### DIFF
--- a/pages/src/contributing.org
+++ b/pages/src/contributing.org
@@ -1,1 +1,11 @@
+** [[file:index.org][Index]]
+   :PROPERTIES:
+   :CUSTOM_ID: index-header
+   :END:
+
 #+INCLUDE: "../../CONTRIBUTING.org" :minlevel 1
+
+** [[file:index.org][Index]]
+   :PROPERTIES:
+   :CUSTOM_ID: index-footer
+   :END:


### PR DESCRIPTION
Couldn't get org-mode's sitemap feature to create the desired navigation links. Thus, manually link back to index page. At least for now.