### PR TITLE
Avoid timeout in non_empty_list_shrink_test

### DIFF
--- a/test/triq_tests.erl
+++ b/test/triq_tests.erl
@@ -163,7 +163,7 @@ non_empty_list_shrink_test() ->
                  [[0]] =:= triq:counterexample(
                            ?FORALL(_, non_empty(list(int())), false))
          end,
-         lists:seq(1, 25))).
+         lists:seq(1, 15))).
 
 %list_shrink2_testx() ->
 %    %% test that a list doesn't easily end in a local 'smallest counterexample'


### PR DESCRIPTION
On Gitlab's CI sometimes the test fails with a timeout. When run locally it
takes about 2 seconds to run on a relatively new laptop. So on a heavly loaded
CI environment it's plausible it would take more than 5 seconds sometime.

Reduce the number of tries from 25 to 15. Now it takes under a second to run,
hopefully that gives it enough headroom in the CI environment.